### PR TITLE
Add front-end APIs for inventory and orders

### DIFF
--- a/client/src/api/auth.js
+++ b/client/src/api/auth.js
@@ -1,0 +1,20 @@
+import axios from "axios";
+import { mockAllUsers } from "../data/mockAllUsers";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL;
+
+export async function login(username, password) {
+  const user = mockAllUsers.find(u => u.username === username && u.password === password);
+  if (user) {
+    return Promise.resolve(user);
+  }
+  // const res = await axios.post(`${API_BASE}/auth/login`, { username, password });
+  // return res.data;
+  return Promise.reject(new Error("Invalid credentials"));
+}
+
+export async function register(data) {
+  // return axios.post(`${API_BASE}/auth/register`, data);
+  console.log("Would register user", data);
+  return Promise.resolve();
+}

--- a/client/src/api/inventory.js
+++ b/client/src/api/inventory.js
@@ -1,0 +1,20 @@
+import axios from "axios";
+import { mockClerkInventory } from "../data/mockClerkInventory";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL;
+
+// 臨時用：直接回傳 mockClerkInventory
+export function fetchInventory() {
+  return Promise.resolve(mockClerkInventory);
+}
+
+// export async function fetchInventory() {
+//   const res = await axios.get(`${API_BASE}/inventory`);
+//   return res.data.items;
+// }
+
+export async function requestStock(itemId) {
+  // return axios.post(`${API_BASE}/inventory/${itemId}/request`);
+  console.log(`Would request stock for item ${itemId}`);
+  return Promise.resolve();
+}

--- a/client/src/api/order.js
+++ b/client/src/api/order.js
@@ -1,0 +1,28 @@
+import axios from "axios";
+import { mockClerkOrders } from "../data/mockClerkOrders";
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL;
+
+// 臨時用：直接回傳 mockClerkOrders
+export function fetchOrders() {
+  return Promise.resolve(mockClerkOrders);
+}
+
+// export async function fetchOrders() {
+//   const res = await axios.get(`${API_BASE}/orders`);
+//   return res.data.orders;
+// }
+
+// 更新訂單狀態
+export async function updateOrderStatus(orderId, status) {
+  // return axios.patch(`${API_BASE}/orders/${orderId}`, { status });
+  console.log(`Would update order ${orderId} to status ${status}`);
+  return Promise.resolve();
+}
+
+// 建立新訂單
+export async function createOrder(orderData) {
+  // return axios.post(`${API_BASE}/orders`, orderData);
+  console.log("Would create order", orderData);
+  return Promise.resolve();
+}

--- a/client/src/hooks/useClerkInventory.js
+++ b/client/src/hooks/useClerkInventory.js
@@ -1,14 +1,17 @@
 // client/src/hooks/useClerkInventory.js
 import { useState, useEffect } from 'react';
-import { mockClerkInventory } from '../data/mockClerkInventory';
+import { fetchInventory as apiFetchInventory, requestStock as apiRequestStock } from '../api/inventory';
 
 export function useClerkInventory() {
   const [inventory, setInventory] = useState([]);
   const [lowStockAlertItems, setLowStockAlertItems] = useState([]);
 
   useEffect(() => {
-    // In a real app, you would fetch this data from an API
-    setInventory(mockClerkInventory);
+    const load = async () => {
+      const data = await apiFetchInventory();
+      setInventory(data);
+    };
+    load();
   }, []);
 
   useEffect(() => {
@@ -16,20 +19,16 @@ export function useClerkInventory() {
     setLowStockAlertItems(lowStockItems);
   }, [inventory]);
 
-  const requestStock = (itemId) => {
-    // Logic to request stock from supplier
+  const requestStock = async (itemId) => {
     const item = inventory.find(item => item.id === itemId);
-    console.log(`Stock requested for item ${itemId}: ${item?.name} (simulated API call)`);
-    // You might want to update the item's state here, e.g., item.stockRequested = true
-    // or call an API to make the request.
+    await apiRequestStock(itemId);
     alert(`已為 ${item?.name} 申請補貨。`);
   };
 
   // Placeholder for future API integration to refresh inventory
-  const refreshInventory = () => {
-    console.log('Refreshing inventory data (simulated API call)');
-    // Potentially re-fetch from mockClerkInventory or an API
-    setInventory(mockClerkInventory); 
+  const refreshInventory = async () => {
+    const data = await apiFetchInventory();
+    setInventory(data);
   };
 
   return { inventory, lowStockAlertItems, requestStock, refreshInventory };

--- a/client/src/hooks/useClerkOrders.js
+++ b/client/src/hooks/useClerkOrders.js
@@ -1,23 +1,25 @@
 // client/src/hooks/useClerkOrders.js
 import { useState, useEffect } from 'react';
-import { mockClerkOrders } from '../data/mockClerkOrders';
+import { fetchOrders as apiFetchOrders, updateOrderStatus as apiUpdateOrderStatus } from '../api/order';
 
 export function useClerkOrders() {
   const [orders, setOrders] = useState([]);
 
   useEffect(() => {
-    // In a real app, you would fetch this data from an API
-    setOrders(mockClerkOrders);
+    const load = async () => {
+      const data = await apiFetchOrders();
+      setOrders(data);
+    };
+    load();
   }, []);
 
-  const updateOrderStatus = (orderId, newStatus) => {
+  const updateOrderStatus = async (orderId, newStatus) => {
     setOrders(prevOrders =>
       prevOrders.map(order =>
         order.id === orderId ? { ...order, status: newStatus } : order
       )
     );
-    // Add API call to update order status in the backend
-    console.log(`Order ${orderId} status updated to ${newStatus} (simulated API call)`);
+    await apiUpdateOrderStatus(orderId, newStatus);
   };
 
   return { orders, updateOrderStatus };

--- a/server/models/InventoryItem.js
+++ b/server/models/InventoryItem.js
@@ -1,0 +1,36 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../config/database.js';
+
+class InventoryItem extends Model {}
+
+InventoryItem.init(
+  {
+    id: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    stock: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    unit: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    lowStockThreshold: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'InventoryItem',
+    tableName: 'InventoryItem',
+  },
+);
+
+export default InventoryItem;

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -1,0 +1,28 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../config/database.js';
+
+class Order extends Model {}
+
+Order.init(
+  {
+    id: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+    },
+    customerName: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'Order',
+    tableName: 'Order',
+  },
+);
+
+export default Order;

--- a/server/models/OrderItem.js
+++ b/server/models/OrderItem.js
@@ -1,0 +1,42 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../config/database.js';
+
+class OrderItem extends Model {}
+
+OrderItem.init(
+  {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    orderId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    quantity: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    size: {
+      type: DataTypes.STRING,
+    },
+    sugar: {
+      type: DataTypes.STRING,
+    },
+    ice: {
+      type: DataTypes.STRING,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'OrderItem',
+    tableName: 'OrderItem',
+  },
+);
+
+export default OrderItem;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,0 +1,36 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../config/database.js';
+
+class User extends Model {}
+
+User.init(
+  {
+    id: {
+      type: DataTypes.STRING,
+      primaryKey: true,
+    },
+    username: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
+    password: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    role: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    name: {
+      type: DataTypes.STRING,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'User',
+    tableName: 'User',
+  },
+);
+
+export default User;


### PR DESCRIPTION
## Summary
- create API modules for auth, inventory, and order data
- use these APIs inside `useClerkOrders` and `useClerkInventory` hooks

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test --prefix server`


------
https://chatgpt.com/codex/tasks/task_e_6845ec3a5b10832c88127097d36d5faa