### PR TITLE
Add seed script for all core models

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## 開發伺服器資料初始化
+
+後端伺服器啟動時會自動呼叫 `sequelize.sync({ alter: true })`，並載入位於 `server/seeders` 目錄的假資料 (`seedUsers.js`、`seedInventory.js`、`seedProducts.js`、`seedOrders.js`)，確保資料表結構與 model 一致並填入初始資料。

--- a/doc/er_diagram.md
+++ b/doc/er_diagram.md
@@ -13,6 +13,8 @@ erDiagram
     string name
     string description
     double price
+    string imageUrl
+    string type
   }
   INVENTORY {
     int productId PK

--- a/server/app.js
+++ b/server/app.js
@@ -6,6 +6,10 @@ import productRouter from "./routes/productRouter.js";
 import orderRouter from "./routes/orderRouter.js";
 import inventoryRouter from "./routes/inventoryRouter.js";
 import sequelize from './config/database.js';
+import seedUsers from './seeders/seedUsers.js';
+import seedInventory from './seeders/seedInventory.js';
+import seedProducts from './seeders/seedProducts.js';
+import seedOrders from './seeders/seedOrders.js';
 
 const app = express();
 const port = process.env.PORT || 3001;
@@ -25,6 +29,16 @@ const startServer = async () => {
   try {
     await sequelize.authenticate();
     console.log('Database connection has been established successfully.');
+
+    // 確保資料表結構與 model 相符
+    await sequelize.sync({ alter: true });
+
+    // 初始化假資料
+    await seedUsers();
+    await seedInventory();
+    await seedProducts();
+    await seedOrders();
+
     app.listen(port, () => {
       console.log(`Server listening on http://localhost:${port}`);
     });

--- a/server/models/Product.js
+++ b/server/models/Product.js
@@ -21,6 +21,12 @@ Product.init(
          type: DataTypes.DOUBLE,
          allowNull: false,
        },
+       imageUrl: {
+         type: DataTypes.STRING,
+       },
+       type: {
+         type: DataTypes.STRING,
+       },
    },{
        sequelize,
        modelName: 'Product',

--- a/server/seeders/seedInventory.js
+++ b/server/seeders/seedInventory.js
@@ -1,0 +1,17 @@
+import InventoryItem from '../models/InventoryItem.js';
+
+const items = [
+  { id: 'ITEM001', name: '紅茶葉', stock: 50, unit: '包', lowStockThreshold: 10 },
+  { id: 'ITEM002', name: '綠茶葉', stock: 8, unit: '包', lowStockThreshold: 10 },
+  { id: 'ITEM003', name: '珍珠', stock: 20, unit: '公斤', lowStockThreshold: 5 },
+  { id: 'ITEM004', name: '牛奶', stock: 15, unit: '瓶', lowStockThreshold: 12 },
+  { id: 'ITEM005', name: '糖漿', stock: 30, unit: '公升', lowStockThreshold: 5 },
+];
+
+export default async function seedInventory() {
+  const count = await InventoryItem.count();
+  if (count === 0) {
+    await InventoryItem.bulkCreate(items);
+    console.log('庫存資料已初始化');
+  }
+}

--- a/server/seeders/seedOrders.js
+++ b/server/seeders/seedOrders.js
@@ -1,0 +1,43 @@
+import Order from '../models/Order.js';
+import OrderItem from '../models/OrderItem.js';
+
+const orders = [
+  {
+    id: 'ORD001',
+    customerName: '劉備',
+    status: '新訂單',
+    items: [
+      { name: '珍珠奶茶', quantity: 2, size: '大杯', sugar: '半糖', ice: '少冰' },
+      { name: '百香果綠茶', quantity: 1, size: '中杯', sugar: '正常糖', ice: '正常冰' },
+    ],
+  },
+  {
+    id: 'ORD002',
+    customerName: '關羽',
+    status: '製作中',
+    items: [
+      { name: '冬瓜茶', quantity: 1, size: '大杯', sugar: '微糖', ice: '去冰' },
+    ],
+  },
+  {
+    id: 'ORD003',
+    customerName: '張飛',
+    status: '新訂單',
+    items: [
+      { name: '芋頭鮮奶', quantity: 3, size: '中杯', sugar: '少糖', ice: '微冰' },
+      { name: '仙草凍奶茶', quantity: 1, size: '大杯', sugar: '無糖', ice: '正常冰' },
+    ],
+  },
+];
+
+export default async function seedOrders() {
+  const count = await Order.count();
+  if (count === 0) {
+    for (const ord of orders) {
+      const { items, ...orderData } = ord;
+      await Order.create(orderData);
+      await OrderItem.bulkCreate(items.map(i => ({ ...i, orderId: ord.id })));
+    }
+    console.log('訂單資料已初始化');
+  }
+}

--- a/server/seeders/seedProducts.js
+++ b/server/seeders/seedProducts.js
@@ -1,0 +1,25 @@
+import Product from '../models/Product.js';
+
+const products = [
+  { id: 1, name: '珍珠奶茶', price: 55, imageUrl: '/src/assets/images/bubbleTea.png', description: '經典奶茶搭配Q彈珍珠，甜而不膩，口感豐富。', type: '奶茶類' },
+  { id: 2, name: '抹茶拿鐵', price: 65, imageUrl: '/src/assets/images/matcha.png', description: '嚴選日本抹茶與鮮奶完美融合，帶有淡淡茶香與奶香。', type: '奶茶類' },
+  { id: 3, name: '鮮奶茶', price: 60, imageUrl: '/src/assets/images/milkTea.png', description: '新鮮牛奶搭配香醇紅茶，口感順滑細緻。', type: '奶茶類' },
+  { id: 4, name: '紅茶', price: 30, imageUrl: '/src/assets/images/blackTea.png', description: '香醇濃厚的純正紅茶，提神醒腦。', type: '原茶類' },
+  { id: 5, name: '綠茶', price: 30, imageUrl: '/src/assets/images/greenTea.png', description: '清新怡人的綠茶，帶有淡淡草本芬芳。', type: '原茶類' },
+  { id: 6, name: '烏龍茶', price: 35, imageUrl: '/src/assets/images/oolongTea.png', description: '香氣濃郁，口感順滑的烏龍茶，回甘十足。', type: '原茶類' },
+  { id: 7, name: '檸檬綠茶', price: 45, imageUrl: '/src/assets/images/lemonGreen.png', description: '清爽酸甜的檸檬與綠茶結合，解渴又提神。', type: '風味茶' },
+  { id: 8, name: '芋頭鮮奶', price: 70, imageUrl: '/src/assets/images/taroMilk.png', description: '香濃滑順的芋頭搭配新鮮牛奶，口感濃郁香甜。', type: '奶茶類' },
+  { id: 9, name: '冬瓜茶', price: 35, imageUrl: '/src/assets/images/winterMelon.png', description: '甘甜清爽的冬瓜茶，適合消暑解渴。', type: '風味茶' },
+  { id: 10, name: '百香果綠茶', price: 50, imageUrl: '/src/assets/images/passionFruit.png', description: '鮮甜百香果搭配綠茶，酸甜適中，滋味豐富。', type: '風味茶' },
+  { id: 11, name: '仙草凍奶茶', price: 60, imageUrl: '/src/assets/images/grassJelly.png', description: '滑嫩仙草凍融合奶茶，口感清涼消暑。', type: '奶茶類' },
+  { id: 12, name: '可可牛奶', price: 65, imageUrl: '/src/assets/images/cocoa.png', description: '濃郁香醇的可可與鮮奶結合，甜而不膩，溫潤滑順。', type: '奶茶類' },
+];
+
+export default async function seedProducts() {
+  const count = await Product.count();
+  if (count === 0) {
+    await Product.bulkCreate(products);
+    console.log('產品資料已初始化');
+  }
+}
+

--- a/server/seeders/seedUsers.js
+++ b/server/seeders/seedUsers.js
@@ -1,0 +1,13 @@
+import User from '../models/User.js';
+
+const users = [
+  { id: 'clerk001', username: '0000', password: '0000', role: 'clerk', name: '店員一號' },
+];
+
+export default async function seedUsers() {
+  const count = await User.count();
+  if (count === 0) {
+    await User.bulkCreate(users);
+    console.log('使用者資料已初始化');
+  }
+}

--- a/server/services/ProductService.js
+++ b/server/services/ProductService.js
@@ -12,15 +12,15 @@ class ProductService {
   }
 
   /** 新增商品 */
-  static async create({ name, description, price }) {
-    return await Product.create({ name, description, price });
+  static async create({ name, description, price, imageUrl, type }) {
+    return await Product.create({ name, description, price, imageUrl, type });
   }
 
   /** 更新商品 */
-  static async update(id, { name, description, price }) {
+  static async update(id, { name, description, price, imageUrl, type }) {
     const product = await Product.findByPk(id);
     if (!product) throw new Error('Product not found');
-    return await product.update({ name, description, price });
+    return await product.update({ name, description, price, imageUrl, type });
   }
 
   /** 刪除商品 */


### PR DESCRIPTION
## Summary
- seed users, inventory items and orders with new scripts
- load all seeders on server start
- document seeding behavior in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845fe711234832cabd3de5a6d407441