### PR TITLE
Fix order item association

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -10,6 +10,8 @@ import seedUsers from './seeders/seedUsers.js';
 import seedInventory from './seeders/seedInventory.js';
 import seedProducts from './seeders/seedProducts.js';
 import seedOrders from './seeders/seedOrders.js';
+// Initialize model associations
+import './models/associations.js';
 
 const app = express();
 const port = process.env.PORT || 3001;

--- a/server/models/associations.js
+++ b/server/models/associations.js
@@ -1,0 +1,8 @@
+import Order from './Order.js';
+import OrderItem from './OrderItem.js';
+
+// Define associations between Order and OrderItem
+Order.hasMany(OrderItem, { foreignKey: 'orderId' });
+OrderItem.belongsTo(Order, { foreignKey: 'orderId' });
+
+export default function applyAssociations() {}


### PR DESCRIPTION
## Summary
- add model associations between `Order` and `OrderItem`
- load associations on app startup

## Testing
- `node -e "import './server/models/associations.js'; import Order from './server/models/Order.js'; console.log(Object.keys(Order.associations));" --experimental-modules`

------
https://chatgpt.com/codex/tasks/task_e_68460e2e64a4832ca4813215cec1448d