### PR TITLE
Fix ClerkDashboard order items mapping

### DIFF
--- a/client/src/api/auth.js
+++ b/client/src/api/auth.js
@@ -1,4 +1,3 @@
-import axios from "axios";
 import { mockAllUsers } from "../data/mockAllUsers";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL;

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -6,19 +6,6 @@ import { FaShoppingCart, FaUser, FaTachometerAlt } from 'react-icons/fa'; // Add
 // import { useCart } from '../hooks/useCart';
 const useCart = () => ({ cartCount: 0 }); // Mocking useCart for now
 
-// Helper function to translate role to Chinese (kept for potential future use)
-const getRoleDisplayName = (role) => {
-  switch (role) {
-    case 'clerk':
-      return '店員';
-    case 'customer':
-      return '顧客';
-    case 'admin':
-      return '管理員';
-    default:
-      return role;
-  }
-};
 
 export default function NavBar({ user, onLogout }) {
   const { cartCount } = useCart();

--- a/client/src/hooks/useClerkOrders.js
+++ b/client/src/hooks/useClerkOrders.js
@@ -8,7 +8,13 @@ export function useClerkOrders() {
   useEffect(() => {
     const load = async () => {
       const data = await apiFetchOrders();
-      setOrders(data);
+      const normalized = data.map((order) => ({
+        ...order,
+        // Sequelize returns associated items under `OrderItems` by default.
+        // Normalize to `items` for the UI components.
+        items: order.items || order.OrderItems || [],
+      }));
+      setOrders(normalized);
     };
     load();
   }, []);

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -2,6 +2,9 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tsconfigPaths from "vite-tsconfig-paths";
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- normalize `OrderItems` to `items` in clerk orders hook
- remove unused code and adjust vite config
- tidy auth API and navbar to satisfy lint

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847d80dc93c832cba1459a2e65370df