### PR TITLE
實作登入註冊功能並以手機為主鍵

### DIFF
--- a/client/src/api/auth.js
+++ b/client/src/api/auth.js
@@ -16,7 +16,7 @@ export async function login(username, password) {
     throw new Error(errorMsg);
   }
   const data = await res.json();
-  return data; // Assuming the backend returns user data/token directly
+  return data.data;
 }
 
 export async function register(userData) {
@@ -38,5 +38,5 @@ export async function register(userData) {
     throw new Error(errorMsg);
   }
   const data = await res.json();
-  return data; // Assuming the backend returns some data upon successful registration
+  return data.data;
 }

--- a/client/src/components/LoginForm.jsx
+++ b/client/src/components/LoginForm.jsx
@@ -1,41 +1,24 @@
 // client/src/components/LoginForm.jsx
 import React, { useState } from 'react';
 import { Form, Button, Alert, Card } from 'react-bootstrap';
+import { login as loginApi } from '../api/auth';
 
-export default function LoginForm({ 
-  onLoginAttempt, 
-  title = "系統登入", 
-  mockUsers = [] 
+export default function LoginForm({
+  onLoginAttempt,
+  title = "系統登入"
 }) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
-  const handleSubmit = (event) => {
+  const handleSubmit = async (event) => {
     event.preventDefault();
     setError('');
-
-    console.log('LoginForm handleSubmit triggered');
-    console.log('Props - title:', title);
-    console.log('Props - mockUsers:', JSON.stringify(mockUsers)); // Be cautious with large user lists
-    console.log('State - username:', username);
-    console.log('State - password:', password);
-
-    const usersArray = Array.isArray(mockUsers) ? mockUsers : [];
-    const user = usersArray.find(
-      (u) => u.username === username && u.password === password
-    );
-
-    console.log('Found user:', JSON.stringify(user));
-
-    if (user) {
-      console.log(`Login successful for user: ${user.username}, role: ${user.role}`);
-      if (onLoginAttempt) {
-        onLoginAttempt(user); // Pass the entire user object
-      }
-    } else {
-      console.error('Login failed. Invalid credentials.');
-      setError('登入失敗，請檢查您的帳號或密碼。若問題持續，請聯繫系統管理員。 ');
+    try {
+      const user = await loginApi(username, password);
+      if (onLoginAttempt) onLoginAttempt(user);
+    } catch (err) {
+      setError(err.message);
     }
   };
 

--- a/client/src/components/RegisterForm.jsx
+++ b/client/src/components/RegisterForm.jsx
@@ -2,31 +2,49 @@
 import React, { useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
+import { register as registerApi } from '../api/auth';
 
 export default function RegisterForm({ className }) { // Add className prop
-  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
 
-  const handleSubmit = (event) => {
+  const handleSubmit = async (event) => {
     event.preventDefault();
-    // Handle registration logic here
     if (password !== confirmPassword) {
       alert("Passwords don't match!");
       return;
     }
-    console.log('Register submitted', { email, password });
+    try {
+      await registerApi({ phone, username, password });
+      alert('Registration successful');
+    } catch (err) {
+      alert(err.message);
+    }
   };
 
   return (
     <Form onSubmit={handleSubmit} className={className}> {/* Use className prop */}
-      <Form.Group className="mb-3" controlId="formBasicEmail">
-        <Form.Label>電子郵件</Form.Label>
+      <Form.Group className="mb-3" controlId="formPhone">
+        <Form.Label>手機號碼</Form.Label>
         <Form.Control
-          type="email"
-          placeholder="輸入電子郵件"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          type="text"
+          placeholder="輸入手機號碼"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          required
+        />
+      </Form.Group>
+
+      <Form.Group className="mb-3" controlId="formUsername">
+        <Form.Label>帳號</Form.Label>
+        <Form.Control
+          type="text"
+          placeholder="輸入帳號"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          required
         />
       </Form.Group>
 

--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Container, Row, Col } from 'react-bootstrap';
 import LoginForm from '../components/LoginForm';
-import { mockAllUsers } from '../data/mockAllUsers';
 
 // The onUserAuthenticated prop is crucial for App.jsx to know about the login
 export default function LoginPage({ onUserAuthenticated }) { 
@@ -45,7 +44,6 @@ export default function LoginPage({ onUserAuthenticated }) {
         <Col md={6} lg={4}>
           <LoginForm
             onLoginAttempt={handleLoginAttempt}
-            mockUsers={mockAllUsers}
             title="系統統一登入"
           />
         </Col>

--- a/server/app.js
+++ b/server/app.js
@@ -5,6 +5,7 @@ import cors from 'cors';
 import productRouter from "./routes/productRouter.js";
 import orderRouter from "./routes/orderRouter.js";
 import inventoryRouter from "./routes/inventoryRouter.js";
+import authRouter from "./routes/authRouter.js";
 import sequelize from './config/database.js';
 import seedUsers from './seeders/seedUsers.js';
 import seedInventory from './seeders/seedInventory.js';
@@ -22,6 +23,7 @@ app.use(express.json());
 app.use("/api/product", productRouter);
 app.use("/api/order", orderRouter);
 app.use("/api/inventory", inventoryRouter);
+app.use("/api/auth", authRouter);
 
 app.get('/', (req, res) => {
   res.send('Server is running!');

--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -1,0 +1,20 @@
+import UserService from '../services/UserService.js';
+
+export const register = async (req, res, next) => {
+  try {
+    const user = await UserService.register(req.body);
+    res.status(201).json({ success: true, data: user });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const login = async (req, res, next) => {
+  try {
+    const user = await UserService.login(req.body.username, req.body.password);
+    if (!user) return res.status(401).json({ success: false, message: 'Invalid credentials' });
+    res.json({ success: true, data: user });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -5,7 +5,7 @@ class User extends Model {}
 
 User.init(
   {
-    id: {
+    phone: {
       type: DataTypes.STRING,
       primaryKey: true,
     },

--- a/server/routes/authRouter.js
+++ b/server/routes/authRouter.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import { login, register } from '../controllers/UserController.js';
+
+const router = express.Router();
+
+router.post('/login', login);
+router.post('/register', register);
+
+export default router;

--- a/server/seeders/seedUsers.js
+++ b/server/seeders/seedUsers.js
@@ -1,7 +1,7 @@
 import User from '../models/User.js';
 
 const users = [
-  { id: 'clerk001', username: '0000', password: '0000', role: 'clerk', name: '店員一號' },
+  { phone: '0912345678', username: '0000', password: '0000', role: 'clerk', name: '店員一號' },
 ];
 
 export default async function seedUsers() {

--- a/server/services/UserService.js
+++ b/server/services/UserService.js
@@ -1,0 +1,16 @@
+import User from '../models/User.js';
+
+class UserService {
+  static async register({ phone, username, password, role = 'customer', name }) {
+    const exists = await User.findByPk(phone);
+    if (exists) throw new Error('User already exists');
+    const user = await User.create({ phone, username, password, role, name });
+    return user;
+  }
+
+  static async login(username, password) {
+    return await User.findOne({ where: { username, password } });
+  }
+}
+
+export default UserService;


### PR DESCRIPTION
## Summary
- 調整 User model 以 phone 為主鍵
- 更新假資料並新增 UserService/UserController
- 新增 /api/auth 路由支援登入與註冊
- 前端登入與註冊表單改與後端互動

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849af8db784832caa5af2c63ed2b882