### PR TITLE
完善購物車與訂單流程

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,5 @@
 // client/src/App.jsx
-import React, { useState } from 'react'; // Added useState
+import React, { useState, useEffect } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom'; // Added Navigate
 import CustomerMainPage from './pages/CustomerMainPage';
 import ProductSearchPage from './pages/ProductSearchPage';
@@ -15,14 +15,35 @@ import ClerkDashboard from './pages/ClerkDashboard'; // Import ClerkDashboard
 export default function App() {
   const [loggedInUser, setLoggedInUser] = useState(null);
 
+  useEffect(() => {
+    const stored = localStorage.getItem('user');
+    if (stored) {
+      setLoggedInUser(JSON.parse(stored));
+    }
+    const syncUser = () => {
+      const u = localStorage.getItem('user');
+      setLoggedInUser(u ? JSON.parse(u) : null);
+    };
+    window.addEventListener('authChanged', syncUser);
+    window.addEventListener('storage', syncUser);
+    return () => {
+      window.removeEventListener('authChanged', syncUser);
+      window.removeEventListener('storage', syncUser);
+    };
+  }, []);
+
   const handleUserAuthenticated = (user) => {
     console.log("App.jsx: User authenticated", user);
     setLoggedInUser(user);
+    localStorage.setItem('user', JSON.stringify(user));
+    window.dispatchEvent(new Event('authChanged'));
   };
 
   // Function to handle logout (can be passed to NavBar or other components)
   const handleLogout = () => {
     setLoggedInUser(null);
+    localStorage.removeItem('user');
+    window.dispatchEvent(new Event('authChanged'));
     // Potentially clear any other user-related state or tokens here
     // Navigate to login page after logout
     // Note: Navigation might need to be handled differently if called from a component not directly in Routes

--- a/client/src/api/order.js
+++ b/client/src/api/order.js
@@ -17,10 +17,17 @@ export async function updateOrderStatus(orderId, status) {
 }
 
 export async function createOrder(orderData) {
-  await fetch(`/api/order`, {
-    // Changed to use proxy
+  const res = await fetch(`/api/order`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(orderData),
   });
+  if (!res.ok) {
+    throw new Error("Failed to create order");
+  }
+  // Notify all tabs that orders have been updated
+  localStorage.setItem("ordersUpdated", Date.now().toString());
+  window.dispatchEvent(new Event("ordersUpdated"));
+  const data = await res.json();
+  return data.data;
 }

--- a/client/src/components/OrderProductList.jsx
+++ b/client/src/components/OrderProductList.jsx
@@ -4,6 +4,7 @@ import { ListGroup, Image, Row, Col, Modal, Button, Spinner, Alert } from 'react
 import ProductCustomization from './ProductCustomization';
 import { useCart } from '../hooks/useCart';
 import { useProducts } from '../hooks/useProducts';
+import { useAuth } from '../hooks/useAuth';
 
 const defaultCustomizationDetails = {
   size: 'L',
@@ -20,6 +21,7 @@ export default function OrderProductList() {
   const [quantity, setQuantity] = useState(defaultQuantity);
 
   const { addToCart } = useCart();
+  const { user } = useAuth();
   const { products, loading, error } = useProducts();
 
   // Memoize initialDetails for ProductCustomization
@@ -51,11 +53,16 @@ export default function OrderProductList() {
   }, []);
 
   const handleAddToCart = useCallback(() => {
+    if (!user) {
+      alert('請先登入');
+      handleCloseModal();
+      return;
+    }
     if (currentProduct) {
       addToCart(currentProduct, quantity, customizationOptions);
     }
     handleCloseModal();
-  }, [currentProduct, quantity, customizationOptions, addToCart, handleCloseModal]);
+  }, [user, currentProduct, quantity, customizationOptions, addToCart, handleCloseModal]);
 
   if (loading) {
     return (

--- a/server/controllers/OrderController.js
+++ b/server/controllers/OrderController.js
@@ -21,9 +21,12 @@ export const getOrder = async (req, res, next) => {
 
 export const createOrder = async (req, res, next) => {
   try {
-    const newOrder = await OrderService.create(req.body);
+    const newOrder = await OrderService.placeOrder(req.body);
     res.status(201).json({ success: true, data: newOrder });
   } catch (err) {
+    if (err.message === 'customerName is required') {
+      return res.status(400).json({ success: false, message: err.message });
+    }
     next(err);
   }
 };

--- a/server/services/OrderService.js
+++ b/server/services/OrderService.js
@@ -14,6 +14,27 @@ class OrderService {
     return await Order.create(data);
   }
 
+  static async placeOrder({ customerName, items }) {
+    if (!customerName) {
+      throw new Error('customerName is required');
+    }
+    const id = `ORD${Date.now()}`;
+    const order = await Order.create({ id, customerName, status: '新訂單' });
+    if (Array.isArray(items) && items.length > 0) {
+      await OrderItem.bulkCreate(
+        items.map((i) => ({
+          orderId: id,
+          name: i.name,
+          quantity: i.quantity,
+          size: i.customization?.size,
+          sugar: i.customization?.sugar,
+          ice: i.customization?.ice,
+        }))
+      );
+    }
+    return await Order.findByPk(id, { include: OrderItem });
+  }
+
   static async updateStatus(id, status) {
     const order = await Order.findByPk(id);
     if (!order) throw new Error('Order not found');


### PR DESCRIPTION
## Summary
- 登入後資訊存入 localStorage 並同步狀態
- 未登入時禁止加入購物車
- 已登入的購物車改為可直接送出訂單
- 後端新增下訂服務 `placeOrder`
- 新增訂單後會通知店員畫面重新載入
- 修正未提供使用者姓名時建立訂單失敗的問題

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849b70c4804832cb35e91c6ee01a13d