### PR TITLE
Add customer order management

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import CartPage from './pages/CartPage';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import ClerkDashboard from './pages/ClerkDashboard'; // Import ClerkDashboard
+import CustomerOrdersPage from './pages/CustomerOrdersPage';
 
 // import { CartProvider } from './context/CartContext'; // Removed CartProvider
 
@@ -87,6 +88,16 @@ export default function App() {
         <Route path="/products" element={<ProductSearchPage />} />
         <Route path="/order" element={<OrderPage />} /> {/* Consider if this needs protection */}
         <Route path="/cart" element={<CartPage />} />   {/* Consider if this needs protection */}
+        <Route
+          path="/my-orders"
+          element={
+            loggedInUser && loggedInUser.role === 'customer' ? (
+              <CustomerOrdersPage />
+            ) : (
+              <Navigate to="/login" state={{ message: '請先登入以查詢訂單' }} />
+            )
+          }
+        />
 
         {/* Fallback for any other unmatched routes */}
         <Route path="*" element={<Navigate to={loggedInUser && loggedInUser.role === 'clerk' ? "/clerk-dashboard" : "/"} />} />

--- a/client/src/api/order.js
+++ b/client/src/api/order.js
@@ -7,6 +7,15 @@ export async function fetchOrders() {
   return data.data;
 }
 
+export async function fetchOrdersByCustomerName(customerName) {
+  const res = await fetch(`/api/order?customerName=${encodeURIComponent(customerName)}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch orders');
+  }
+  const data = await res.json();
+  return data.data;
+}
+
 export async function updateOrderStatus(orderId, status) {
   await fetch(`/api/order/${orderId}/status`, {
     // Changed to use proxy
@@ -28,6 +37,17 @@ export async function createOrder(orderData) {
   // Notify all tabs that orders have been updated
   localStorage.setItem("ordersUpdated", Date.now().toString());
   window.dispatchEvent(new Event("ordersUpdated"));
+  const data = await res.json();
+  return data.data;
+}
+
+export async function cancelOrder(orderId) {
+  const res = await fetch(`/api/order/${orderId}/cancel`, {
+    method: 'PATCH'
+  });
+  if (!res.ok) {
+    throw new Error('Failed to cancel order');
+  }
   const data = await res.json();
   return data.data;
 }

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -51,6 +51,11 @@ export default function NavBar({ user, onLogout }) {
                     訂購專區
                   </Nav.Link>
                 )}
+                {user && user.role === 'customer' && (
+                  <Nav.Link as={Link} to="/my-orders">
+                    訂單查詢
+                  </Nav.Link>
+                )}
                 {/* Show Cart link only if user is a customer or not logged in */}
                 {(!user || user.role === 'customer') && (
                   <Nav.Link as={Link} to="/cart" className="nav-icon-link">

--- a/client/src/hooks/useCustomerOrders.js
+++ b/client/src/hooks/useCustomerOrders.js
@@ -1,0 +1,34 @@
+import { useState, useEffect, useCallback } from 'react';
+import { fetchOrdersByCustomerName, cancelOrder as apiCancelOrder } from '../api/order';
+import { useAuth } from './useAuth';
+
+export function useCustomerOrders() {
+  const { user } = useAuth();
+  const [orders, setOrders] = useState([]);
+
+  const load = useCallback(async () => {
+    if (!user) return;
+    const data = await fetchOrdersByCustomerName(user.name || user.username);
+    const normalized = data.map((order) => ({
+      ...order,
+      items: order.items || order.OrderItems || [],
+    }));
+    setOrders(normalized);
+  }, [user]);
+
+  useEffect(() => {
+    load();
+    const handleUpdated = () => load();
+    window.addEventListener('ordersUpdated', handleUpdated);
+    return () => {
+      window.removeEventListener('ordersUpdated', handleUpdated);
+    };
+  }, [load]);
+
+  const cancel = async (id) => {
+    await apiCancelOrder(id);
+    await load();
+  };
+
+  return { orders, cancelOrder: cancel, reload: load };
+}

--- a/client/src/pages/CustomerOrdersPage.jsx
+++ b/client/src/pages/CustomerOrdersPage.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Container, Row, Col, Card, ListGroup, Badge, Button } from 'react-bootstrap';
+import { useCustomerOrders } from '../hooks/useCustomerOrders';
+
+export default function CustomerOrdersPage() {
+  const { orders, cancelOrder } = useCustomerOrders();
+
+  const inProgress = orders.filter(o => ['新訂單', '製作中'].includes(o.status));
+  const history = orders.filter(o => !['新訂單', '製作中'].includes(o.status));
+
+  const renderItems = (order) => (
+    <ul className="mt-2 mb-0 list-unstyled">
+      {order.items.map((item, idx) => (
+        <li key={idx}>{item.name} x {item.quantity}</li>
+      ))}
+    </ul>
+  );
+
+  return (
+    <Container className="mt-5 pt-5">
+      <h1 className="mb-4">訂單查詢</h1>
+      <Row>
+        <Col md={6} className="mb-4">
+          <Card className="shadow-sm">
+            <Card.Header as="h2" className="h5">進行中訂單</Card.Header>
+            <Card.Body>
+              {inProgress.length === 0 ? (
+                <p>沒有進行中的訂單</p>
+              ) : (
+                <ListGroup variant="flush">
+                  {inProgress.map(order => (
+                    <ListGroup.Item key={order.id} className="mb-3 border rounded p-3">
+                      <Row className="align-items-center">
+                        <Col xs={5}><strong>訂單號:</strong> {order.id}</Col>
+                        <Col xs={4}><Badge bg={order.status === '新訂單' ? 'info' : 'warning'}>{order.status}</Badge></Col>
+                        <Col xs={3} className="text-end">
+                          <Button variant="outline-danger" size="sm" onClick={() => cancelOrder(order.id)}>
+                            取消
+                          </Button>
+                        </Col>
+                      </Row>
+                      {renderItems(order)}
+                    </ListGroup.Item>
+                  ))}
+                </ListGroup>
+              )}
+            </Card.Body>
+          </Card>
+        </Col>
+        <Col md={6} className="mb-4">
+          <Card className="shadow-sm">
+            <Card.Header as="h2" className="h5">歷史訂單</Card.Header>
+            <Card.Body>
+              {history.length === 0 ? (
+                <p>沒有歷史訂單</p>
+              ) : (
+                <ListGroup variant="flush">
+                  {history.map(order => (
+                    <ListGroup.Item key={order.id} className="mb-3 border rounded p-3">
+                      <Row className="align-items-center">
+                        <Col xs={6}><strong>訂單號:</strong> {order.id}</Col>
+                        <Col xs={6} className="text-end">
+                          <Badge bg={order.status === '已取消' ? 'secondary' : 'success'}>{order.status}</Badge>
+                        </Col>
+                      </Row>
+                      {renderItems(order)}
+                    </ListGroup.Item>
+                  ))}
+                </ListGroup>
+              )}
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
+    </Container>
+  );
+}

--- a/server/controllers/OrderController.js
+++ b/server/controllers/OrderController.js
@@ -2,7 +2,10 @@ import OrderService from '../services/OrderService.js';
 
 export const getOrders = async (req, res, next) => {
   try {
-    const orders = await OrderService.getAll();
+    const { customerName } = req.query;
+    const orders = customerName
+      ? await OrderService.getByCustomerName(customerName)
+      : await OrderService.getAll();
     res.json({ success: true, data: orders });
   } catch (err) {
     next(err);
@@ -34,6 +37,15 @@ export const createOrder = async (req, res, next) => {
 export const updateOrderStatus = async (req, res, next) => {
   try {
     const updated = await OrderService.updateStatus(req.params.id, req.body.status);
+    res.json({ success: true, data: updated });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const cancelOrder = async (req, res, next) => {
+  try {
+    const updated = await OrderService.cancelOrder(req.params.id);
     res.json({ success: true, data: updated });
   } catch (err) {
     next(err);

--- a/server/routes/orderRouter.js
+++ b/server/routes/orderRouter.js
@@ -4,6 +4,7 @@ import {
   getOrder,
   createOrder,
   updateOrderStatus,
+  cancelOrder,
 } from "../controllers/OrderController.js";
 
 const router = express.Router();
@@ -12,5 +13,6 @@ router.get("/", getOrders);
 router.get("/:id", getOrder);
 router.post("/", createOrder);
 router.patch("/:id/status", updateOrderStatus);
+router.patch("/:id/cancel", cancelOrder);
 
 export default router;

--- a/server/services/OrderService.js
+++ b/server/services/OrderService.js
@@ -6,6 +6,13 @@ class OrderService {
     return await Order.findAll({ include: OrderItem });
   }
 
+  static async getByCustomerName(customerName) {
+    return await Order.findAll({
+      where: { customerName },
+      include: OrderItem,
+    });
+  }
+
   static async getById(id) {
     return await Order.findByPk(id, { include: OrderItem });
   }
@@ -39,6 +46,15 @@ class OrderService {
     const order = await Order.findByPk(id);
     if (!order) throw new Error('Order not found');
     return await order.update({ status });
+  }
+
+  static async cancelOrder(id) {
+    const order = await Order.findByPk(id);
+    if (!order) throw new Error('Order not found');
+    if (!['新訂單', '製作中'].includes(order.status)) {
+      throw new Error('Order cannot be cancelled');
+    }
+    return await order.update({ status: '已取消' });
   }
 }
 


### PR DESCRIPTION
## Summary
- allow querying orders by customer name in backend
- enable order cancellation API
- add customer-specific order hook and page
- link order lookup in navbar and routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a0b84125c832c91dddcb363d7d28c